### PR TITLE
Update ci-lint.yml

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: install npm packages
         run: npm install
       - name: lint


### PR DESCRIPTION
use checkout@v4 because of node16 is depricated